### PR TITLE
[ros2] Update project urls after GitHub migration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ ament_auto_find_build_dependencies()
 
 include(ExternalProject)
 ExternalProject_Add(qpoases_3_2
-  SVN_REPOSITORY https://projects.coin-or.org/svn/qpOASES/stable/3.2
-  SVN_TRUST_CERT TRUE
+  GIT_REPOSITORY https://github.com/coin-or/qpOASES
+  # https://github.com/coin-or/qpOASES/releases/tag/releases%2F3.2.1
+  GIT_TAG 51d3fbea30142d3acbf40cf7a1c519efc27ea67b
   BUILD_IN_SOURCE TRUE
   INSTALL_COMMAND ""
 )

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <license>Apache License 2.0</license>  <!-- This package is Apache 2.0 -->
   <license>LGPL</license>  <!-- qpOASES is LGPL 2.1 -->
 
-  <url type="website">https://projects.coin-or.org/qpOASES</url>
+  <url type="website">https://github.com/coin-or/qpOASES</url>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>subversion</depend>
+  <depend>git</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This package has apparently migrated to GitHub and as a result recent builds [on Rolling](https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__qpoases_vendor__ubuntu_jammy_amd64__binary/66/) are failing to fetch the project from the previous Subversion repository.

I've updated the project url in the package.xml as well as the dependency key (subversion -> git) and the download step configuration for the external CMake project.

The package builds locally with this patch but I have not done any testing beyond that.

This package will likely be removed in the next Rolling sync if the issue isn't addressed.